### PR TITLE
Merge AtoM XLIFF files

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ Example import:
     $ ./import_from_atom --atom-dir="$HOME/atom" --weblate-dir="$HOME/atom-translations"
 
 In addition to copying the XLIFF files it will also process them so they're
-suitable for Weblate (among other things, adding "approved" and "translated"
-attributes to each XLIFF translation unit that's already been translated).
+suitable for Weblate (among other things, adding "approved" attribute to 
+each XLIFF translation unit that's already been translated).
 
 The script will then offer to Git commit the XLIFF files in the i18n
 subdirectory of the Weblate AtoM translations repo and Git push the changes.
@@ -155,8 +155,8 @@ If the `--approved` flag isn't set all translation units will be exported to
 AtoM (used for testing out unapproved translations).
 
 In addition to copying the XLIFF files it will also process them so they're 
-suitable for AtoM (among other things, removing the "approved" and "translated" 
-attributes for each XLIFF translation unit that's been translated).
+suitable for AtoM (among other things, removing the "approved" attribute 
+for each XLIFF translation unit that's been translated).
 
 The script will then offer to Git commit the XLIFF files in the
 `apps/qubit/i18n` subdirectory of the AtoM repo and Git push the changes.
@@ -184,8 +184,8 @@ option. For example: `--language="ca"`.
 Approving all translation units in an XLIFF file
 ------------------------------------------------
 
-Run script to mark all translation units in one or more XLIFF file(s) as `approved`
-and `translated`.
+Run script to mark all translation units in one or more XLIFF file(s) as
+`approved`.
 
 Example:
 

--- a/export_to_atom
+++ b/export_to_atom
@@ -175,8 +175,8 @@ fi
 # Extract all translations to .tx folder before comparison to Weblate's strings.
 phing i18n-push-translations
 
-# Export XLIFF to AtoM. XLIFF will overwrite what is currently in .tx folder.
-$SCRIPT_DIR/scripts/migrate --export --overwrite --language="$LANG_CODE" $APPROVED_OPTION $WEBLATE_DIR/i18n $ATOM_DIR/$ATOM_SOURCE_DIR
+# Export XLIFF to AtoM. XLIFF will be merged into what is currently in .tx folder.
+$SCRIPT_DIR/scripts/migrate --export --merge --language="$LANG_CODE" $APPROVED_OPTION $WEBLATE_DIR/i18n $ATOM_DIR/$ATOM_SOURCE_DIR
 
 # Split .tx files into /apps/qubit/i18n and plugin i18n folders.
 phing i18n-pull-translations

--- a/export_to_atom
+++ b/export_to_atom
@@ -175,59 +175,49 @@ fi
 # Extract all translations to .tx folder before comparison to Weblate's strings.
 phing i18n-push-translations
 
-# Compare AtoM XLIFF to Weblate XLIFF to see if an import is needed
-$SCRIPT_DIR/scripts/compare $APPROVED_OPTION --no-warning --language="$LANG_CODE" $ATOM_DIR/$ATOM_SOURCE_DIR $WEBLATE_DIR/i18n
+# Export XLIFF to AtoM. XLIFF will overwrite what is currently in .tx folder.
+$SCRIPT_DIR/scripts/migrate --export --overwrite --language="$LANG_CODE" $APPROVED_OPTION $WEBLATE_DIR/i18n $ATOM_DIR/$ATOM_SOURCE_DIR
 
-# Import if Atom's not up to date
-if [ $? -ne 0 ]
+# Split .tx files into /apps/qubit/i18n and plugin i18n folders.
+phing i18n-pull-translations
+
+#######################################
+# Commit and push imported XLIFF files.
+# Optional parameter: commit message
+#######################################
+function commit_and_push () {
+    git add apps/qubit/i18n
+    git add plugins
+    git add data/fixtures
+    if [[ ${!1} ]];then
+        git commit -m "$1"
+    else
+        git commit;
+    fi
+    git push
+}
+
+# Offer to commit and push changes if XLIFF was imported successfully
+if [ $? -eq 0 ]
 then
+    cd $ATOM_DIR
 
-    # Export XLIFF to AtoM. XLIFF will overwrite what is currently in .tx folder.
-    $SCRIPT_DIR/scripts/migrate --export --overwrite --language="$LANG_CODE" $APPROVED_OPTION $WEBLATE_DIR/i18n $ATOM_DIR/$ATOM_SOURCE_DIR
+    echo
 
-    # Split .tx files into /apps/qubit/i18n and plugin i18n folders.
-    phing i18n-pull-translations
-
-    #######################################
-    # Commit and push imported XLIFF files.
-    # Optional parameter: commit message
-    #######################################
-    function commit_and_push () {
-        git add apps/qubit/i18n
-        git add plugins
-        git add data/fixtures
-        if [[ ${!1} ]];then
-          git commit -m "$1"
+    if [ "$NO_PUSH" = false ]; then
+        if [ "$COMMIT_WITH_MESSAGE" = false ]; then
+            while true; do
+                read -p "Do you wish to commit the changes to the AtoM repo and push them? " yn
+                case $yn in
+                    [Yy]* ) commit_and_push; break;;
+                    [Nn]* ) exit;;
+                    * ) echo "Please answer yes or no.";;
+                esac
+            done
         else
-          git commit;
-        fi
-        git push
-    }
-
-    # Offer to commit and push changes if XLIFF was imported successfully
-    if [ $? -eq 0 ]
-    then
-        cd $ATOM_DIR
-
-        echo
-
-        if [ "$NO_PUSH" = false ]; then
-            if [ "$COMMIT_WITH_MESSAGE" = false ]; then
-                while true; do
-                    read -p "Do you wish to commit the changes to the AtoM repo and push them? " yn
-                    case $yn in
-                        [Yy]* ) commit_and_push; break;;
-                        [Nn]* ) exit;;
-                        * ) echo "Please answer yes or no.";;
-                    esac
-                done
-            else
-                commit_and_push "$COMMIT_WITH_MESSAGE"
-            fi
+            commit_and_push "$COMMIT_WITH_MESSAGE"
         fi
     fi
-else
-    echo "No export needed."
 fi
 
 # Return to inital directory

--- a/export_to_atom
+++ b/export_to_atom
@@ -182,8 +182,8 @@ $SCRIPT_DIR/scripts/compare $APPROVED_OPTION --no-warning --language="$LANG_CODE
 if [ $? -ne 0 ]
 then
 
-    # Export XLIFF to AtoM
-    $SCRIPT_DIR/scripts/migrate --export --language="$LANG_CODE" $APPROVED_OPTION $WEBLATE_DIR/i18n $ATOM_DIR/$ATOM_SOURCE_DIR
+    # Export XLIFF to AtoM. XLIFF will overwrite what is currently in .tx folder.
+    $SCRIPT_DIR/scripts/migrate --export --overwrite --language="$LANG_CODE" $APPROVED_OPTION $WEBLATE_DIR/i18n $ATOM_DIR/$ATOM_SOURCE_DIR
 
     # Split .tx files into /apps/qubit/i18n and plugin i18n folders.
     phing i18n-pull-translations

--- a/import_from_atom
+++ b/import_from_atom
@@ -80,6 +80,10 @@ while [ "$1" != "" ]; do
             SKIP_PUSH_TRANSLATIONS=true
             VALUE=true
             ;;
+        --overwrite-weblate-xliff)
+            OVERWRITE=true
+            VALUE=true
+            ;;
         *)
             echo "ERROR: unknown parameter \"$PARAM\""
             usage
@@ -139,13 +143,13 @@ fi
 # Change to AtoM directory and extract AtoM source strings,
 echo "Extracting source strings from source code and adding them to AtoM XLIFF files..."
 echo
+
 # Extract AtoM and plugin translations and merge all into AtoM's .tx folder
 if [ "$SKIP_PUSH_TRANSLATIONS" = false ]; then
     # This takes about .5 hours to run. If .tx already contains the combined XLIFF
     # required then this step can be skipped.
     phing i18n-push-translations
 fi
-
 
 # Display currently checked out Weblate and AtoM branches
 echo "The Weblate repository has the '$WEBLATE_BRANCH' branch checked out."
@@ -174,7 +178,12 @@ if [ $? -ne 0 ]
 then
 
     # Attempt import
-    $SCRIPT_DIR/scripts/migrate --import --language="$LANG_CODE" $ATOM_DIR/$ATOM_SOURCE_DIR $WEBLATE_DIR/i18n
+    if [ "$OVERWRITE" = true ]; then
+        $SCRIPT_DIR/scripts/migrate --overwrite --import --language="$LANG_CODE" $ATOM_DIR/$ATOM_SOURCE_DIR $WEBLATE_DIR/i18n
+    else
+        $SCRIPT_DIR/scripts/migrate --merge --import --language="$LANG_CODE" $ATOM_DIR/$ATOM_SOURCE_DIR $WEBLATE_DIR/i18n
+    fi
+
     MIGRATE_SUCCESS=$?
 
     # Check out AtoM i18n and plugins directory to remove changed local files

--- a/import_from_atom
+++ b/import_from_atom
@@ -84,6 +84,10 @@ while [ "$1" != "" ]; do
             OVERWRITE=true
             VALUE=true
             ;;
+        --remove-translated-attribute)
+            REMOVE_TRANSLATED=true
+            VALUE=true
+            ;;
         *)
             echo "ERROR: unknown parameter \"$PARAM\""
             usage
@@ -177,12 +181,24 @@ $SCRIPT_DIR/scripts/compare --language="$LANG_CODE" $ATOM_DIR/$ATOM_SOURCE_DIR $
 if [ $? -ne 0 ]
 then
 
-    # Attempt import
+    MIGRATE_COMMAND="$SCRIPT_DIR/scripts/migrate"
+    MIGRATE_OPTIONS=""
+
     if [ "$OVERWRITE" = true ]; then
-        $SCRIPT_DIR/scripts/migrate --overwrite --import --language="$LANG_CODE" $ATOM_DIR/$ATOM_SOURCE_DIR $WEBLATE_DIR/i18n
+        MIGRATE_OPTIONS="$MIGRATE_OPTIONS --overwrite"
     else
-        $SCRIPT_DIR/scripts/migrate --merge --import --language="$LANG_CODE" $ATOM_DIR/$ATOM_SOURCE_DIR $WEBLATE_DIR/i18n
+        MIGRATE_OPTIONS="$MIGRATE_OPTIONS --merge"
     fi
+
+    if [ "$REMOVE_TRANSLATED" = true ]; then
+        MIGRATE_OPTIONS="$MIGRATE_OPTIONS --remove-translated"
+    fi
+
+    MIGRATE_COMMAND="$MIGRATE_COMMAND $MIGRATE_OPTIONS --import --language="$LANG_CODE" $ATOM_DIR/$ATOM_SOURCE_DIR $WEBLATE_DIR/i18n"
+    
+    echo "$MIGRATE_COMMAND" 
+    # Attempt import
+    $MIGRATE_COMMAND
 
     MIGRATE_SUCCESS=$?
 

--- a/scripts/include/helpers.inc.php
+++ b/scripts/include/helpers.inc.php
@@ -105,7 +105,7 @@ function mergeXliffDom(DOMDocument $domA, DOMDocument $domB): DOMDocument
     if (in_array($source->nodeValue, $removeFromB)) {
       // get parent which should be a trans-unit
       $parent = $source->parentNode;
-      // add trans-unit as child of domB body
+      // remove trans-unit as child of domB body
       $bodyB = $domB->getElementsByTagName('body')[0];
       $bodyB->removeChild($parent);
     }
@@ -150,8 +150,19 @@ function formatXliffForAtom($file, $options = array())
 
   foreach ($elements as $element) {
     if (!empty($options['approved']) && strtolower($element->getAttribute('approved')) != 'yes') {
-      // Remove translation unit if it's not approved
-      $element->parentNode->removeChild($element);
+        // Remove translation unit if it's not approved
+        $element->parentNode->removeChild($element);
+      /*
+      // Remove target translation if it's not approved, leaving the trans-unit in place.
+      foreach ($element->childNodes as $child ) {
+        if ($child->nodeName == 'target') {
+          $element->removeChild($child);
+          // Append empty <target/> to match Weblate's XLIFF export style.
+          $node = $dom->createElement('target');
+          $element->appendChild($node);
+        }
+      }
+      */
     }
     else {
       // Remove approved attribute

--- a/scripts/include/helpers.inc.php
+++ b/scripts/include/helpers.inc.php
@@ -110,10 +110,10 @@ function mergeXliffDom(DOMDocument $domA, DOMDocument $domB): DOMDocument
   return $domB;
 }
 
-function formatXliffForWeblate($file)
+function formatXliffForWeblate($file, $setApproved = false)
 {
   // Add 'approved' and 'translated' attributes
-  addTransUnitAttributes($file);
+  addTransUnitAttributes($file, $setApproved);
 
   // Load XLIFF file into DOM document
   $dom = new DOMDocument();
@@ -128,7 +128,7 @@ function formatXliffForWeblate($file)
   file_put_contents($file, $xml);
 }
 
-function addTransUnitAttributes($file, $preserveIds = false)
+function addTransUnitAttributes($file, $setApproved = false, $preserveIds = false)
 {
   $changed = 0;
 
@@ -147,21 +147,23 @@ function addTransUnitAttributes($file, $preserveIds = false)
       if ($id != sha1($source))
       {
         $element['id'] = sha1($source);
+
+        $changed++;
       }
     }
 
     // Set "approved" and "translated" attributes so Weblate knows translation status
-    if (count($element->xpath('source')) && count($element->xpath('target')) && !empty(trim($element->xpath('target')[0]->__toString())))
+    if ($setApproved && count($element->xpath('source')) && count($element->xpath('target')) && !empty(trim($element->xpath('target')[0]->__toString())))
     {
       // Set "approved" attribute
       if (!isset($element['approved']) || strtolower($element['approved']) != 'yes')
       {
         if (!isset($element['approved']))
-	{
+	      {
           $element->addAttribute('approved', 'yes');
-	}
-	else
-	{
+	      }
+	      else
+	      {
           $element['approved'] = 'yes';
         }
 

--- a/scripts/migrate
+++ b/scripts/migrate
@@ -94,7 +94,7 @@ function migrate($fromI18nDir, $toI18nDir, $options = array())
           if (!file_exists($toFile)) {
             print "Copying new file from AtoM: " . $toFile . "\n";
             copy($fromFile, $toFile);
-            formatXliffForWeblate($toFile);
+            //formatXliffForWeblate($toFile);
           }
           else {
             mergeXliffAtomToWeblate($fromFile, $toFile);
@@ -102,7 +102,8 @@ function migrate($fromI18nDir, $toI18nDir, $options = array())
         }
 
         // Add approved and translated properties when overwriting XLIFF.
-        if (!empty($options['import']) && !empty($options['overwrite'])) {
+        //if (!empty($options['import']) && !empty($options['overwrite'])) {
+        if (!empty($options['import'])) {
           formatXliffForWeblate($toFile);
         }
 

--- a/scripts/migrate
+++ b/scripts/migrate
@@ -3,45 +3,6 @@
 
 include('include/helpers.inc.php');
 
-function formatXliffForAtom($file, $options = array())
-{
-  // Load XLIFF file into DOM document (tidying so whitespace is same as in AtoM)
-  $dom = new DOMDocument();
-  $dom->preserveWhiteSpace = false;
-  $dom->formatOutput = true;
-
-  $dom->load($file);
-
-  // Remove 'approved' and 'translated' attributes
-  $xpath = new DOMXPath($dom);
-  $elements = $xpath->evaluate("//trans-unit");
-
-  foreach ($elements as $element) {
-    if (!empty($options['approved']) && strtolower($element->getAttribute('approved')) != 'yes' && strtolower($element->getAttribute('translated')) != 'yes') {
-      // Remove translation unit if it's not translated and approved
-      $element->parentNode->removeChild($element);
-    }
-    else {
-      // Remove approved and translated attributes
-      $element->removeAttribute('approved');
-      $element->removeAttribute('translated');
-    }
-  }
-
-  // Correct XML and DOCTYPE
-  $newDom = new DOMDocument();
-  $domImp = new DOMImplementation();
-  $newDom->appendChild($domImp->createDocumentType('xliff PUBLIC "-//XLIFF//DTD XLIFF//EN" "http://www.oasis-open.org/committees/xliff/documents/xliff.dtd"'));
-
-  // Create XML fragment with XLIFF element
-  $xliffFragment = $newDom->createDocumentFragment();
-  $xliffFragment->appendXml($dom->saveXml($dom->documentElement));
-
-  $newDom->appendChild($xliffFragment);
-
-  $newDom->save($file);
-}
-
 function migrate($fromI18nDir, $toI18nDir, $options = array())
 {
   abortIfDirectoryDoesNotExist($toI18nDir);
@@ -94,20 +55,21 @@ function migrate($fromI18nDir, $toI18nDir, $options = array())
           if (!file_exists($toFile)) {
             print "Copying new file from AtoM: " . $toFile . "\n";
             copy($fromFile, $toFile);
-            //formatXliffForWeblate($toFile);
           }
           else {
             mergeXliffAtomToWeblate($fromFile, $toFile);
           }
         }
 
-        // Add approved and translated properties when overwriting XLIFF.
-        //if (!empty($options['import']) && !empty($options['overwrite'])) {
+        if (!empty($options['remove-translated'])) {
+          removeTranslatedAttribute($toFile);
+        }
+
         if (!empty($options['import'])) {
           formatXliffForWeblate($toFile);
         }
 
-        // Remove approved and translated properties
+        // Remove approved attribute
         if (!empty($options['export'])) {
           formatXliffForAtom($toFile, $options);
         }
@@ -150,13 +112,13 @@ if (empty($flags['export']) && !empty($flags['approved'])) {
 if (!empty($flags['import'])) {
   print "Importing from AtoM...\n";
   if (!empty($flags['overwrite'])) {
-    print "The 'approved' and 'translated' attributes will be added for translated units.\n";
+    print "The 'approved' attributes will be added for translated units.\n";
   }
 }
 elseif (!empty($flags['export'])) {
   print "Exporting to AtoM...\n";
   if (!empty($flags['overwrite'])) {
-    print "The 'approved' and 'translated' attributes will be removed from translation units.\n";
+    print "The 'approved' attributes will be removed from translation units.\n";
   }
 }
 

--- a/scripts/migrate
+++ b/scripts/migrate
@@ -40,24 +40,30 @@ function migrate($fromI18nDir, $toI18nDir, $options = array())
           print "Created ". $destLangDir ."\n";
         }
 
-        // Copy AtoM's XLIFF file into repo (replacing if a file already exists)
         $langFileRelativePath = $langDir . DIRECTORY_SEPARATOR . "messages.xml";
         $fromFile = $fromI18nDir . DIRECTORY_SEPARATOR . $langFileRelativePath;
         $toFile = $toI18nDir . DIRECTORY_SEPARATOR . $langFileRelativePath;
 
         print "Migrating ". $fromFile . " -> " . $toFile ."\n";
 
+        // 'Approved' can only be set on export. Only relevant when moving strings
+        // from Weblate -> AtoM.
+        if (!empty($options['approved']) && !empty($options['export'])) {
+            print "Omitting unapproved strings.\n";
+            filterUnapprovedTransUnits($fromFile);
+        }
+
         if (!empty($options['overwrite'])) {
           copy($fromFile, $toFile);
         }
         else if (!empty($options['merge'])) {
-          // Copy AtoM XLIFF file to Weblate if it is not found
           if (!file_exists($toFile)) {
-            print "Copying new file from AtoM: " . $toFile . "\n";
+            print "Copying file from : " . $fromFile . "\n";
             copy($fromFile, $toFile);
           }
           else {
-            mergeXliffAtomToWeblate($fromFile, $toFile);
+            print "Merging files into: " . $toFile . "\n";
+            mergeXliff($fromFile, $toFile, !empty($options['export']));
           }
         }
 
@@ -69,7 +75,6 @@ function migrate($fromI18nDir, $toI18nDir, $options = array())
           formatXliffForWeblate($toFile);
         }
 
-        // Remove approved attribute
         if (!empty($options['export'])) {
           formatXliffForAtom($toFile, $options);
         }

--- a/scripts/migrate
+++ b/scripts/migrate
@@ -16,15 +16,12 @@ function formatXliffForAtom($file, $options = array())
   $xpath = new DOMXPath($dom);
   $elements = $xpath->evaluate("//trans-unit");
 
-  foreach ($elements as $element)
-  {
-    if (!empty($options['approved']) && strtolower($element->getAttribute('approved')) != 'yes' && strtolower($element->getAttribute('translated')) != 'yes')
-    {
+  foreach ($elements as $element) {
+    if (!empty($options['approved']) && strtolower($element->getAttribute('approved')) != 'yes' && strtolower($element->getAttribute('translated')) != 'yes') {
       // Remove translation unit if it's not translated and approved
       $element->parentNode->removeChild($element);
     }
-    else
-    {
+    else {
       // Remove approved and translated attributes
       $element->removeAttribute('approved');
       $element->removeAttribute('translated');
@@ -51,16 +48,14 @@ function migrate($fromI18nDir, $toI18nDir, $options = array())
 
   // Cycle through each AtoM language directory
   print "Attempting to cycle through language directories in ". $fromI18nDir ."...\n";
-  try
-  {
+  try {
     $dir = new DirectoryIterator($fromI18nDir);
   }
-  catch(Exception $e)
-  {
+  catch(Exception $e) {
     abort('Unable to access '. $fromI18nDir);
   }
 
-  $copyCount = 0;
+  $count = 0;
 
   foreach ($dir as $fileinfo)
   {
@@ -68,21 +63,18 @@ function migrate($fromI18nDir, $toI18nDir, $options = array())
       $langDir = $fileinfo->getFilename();
 
       // If a language is specified, skip if this isn't the one
-      if (isset($options['language']) && $options['language'] != 'all' && $options['language'] != $langDir)
-      {
+      if (isset($options['language']) && $options['language'] != 'all' && $options['language'] != $langDir) {
         print "Skipped language '". $langDir ."'.\n";
         continue;
       }
 
       // There's no need to migrate English as it doesn't need to be translated
-      if (is_dir($fromI18nDir . DIRECTORY_SEPARATOR . $langDir) && $langDir != 'en')
-      {
+      if (is_dir($fromI18nDir . DIRECTORY_SEPARATOR . $langDir) && $langDir != 'en') {
         // Each language's XLIFF file'll end up in a subdir of the i18n directory
         $destLangDir = $toI18nDir . DIRECTORY_SEPARATOR . $langDir;
 
         // Create destination language directory if it doesn't exist
-        if (!is_dir($destLangDir))
-        {
+        if (!is_dir($destLangDir)) {
           mkdir($destLangDir);
           print "Created ". $destLangDir ."\n";
         }
@@ -91,31 +83,44 @@ function migrate($fromI18nDir, $toI18nDir, $options = array())
         $langFileRelativePath = $langDir . DIRECTORY_SEPARATOR . "messages.xml";
         $fromFile = $fromI18nDir . DIRECTORY_SEPARATOR . $langFileRelativePath;
         $toFile = $toI18nDir . DIRECTORY_SEPARATOR . $langFileRelativePath;
-        copy($fromFile, $toFile);
 
-        // Add approved and translated properties
-        if (!empty($options['import']))
-        {
+        print "Migrating ". $fromFile . " -> " . $toFile ."\n";
+
+        if (!empty($options['overwrite'])) {
+          copy($fromFile, $toFile);
+        }
+        else if (!empty($options['merge'])) {
+          // Copy AtoM XLIFF file to Weblate if it is not found
+          if (!file_exists($toFile)) {
+            print "Copying new file from AtoM: " . $toFile . "\n";
+            copy($fromFile, $toFile);
+            formatXliffForWeblate($toFile);
+          }
+          else {
+            mergeXliffAtomToWeblate($fromFile, $toFile);
+          }
+        }
+
+        // Add approved and translated properties when overwriting XLIFF.
+        if (!empty($options['import']) && !empty($options['overwrite'])) {
           formatXliffForWeblate($toFile);
         }
 
         // Remove approved and translated properties
-        if (!empty($options['export']))
-        {
+        if (!empty($options['export'])) {
           formatXliffForAtom($toFile, $options);
         }
 
-        if (!empty($options['debug']))
-        {
+        if (!empty($options['debug'])) {
           print 'DEBUG: Updated '. $toFile ." (". filesize($toFile) ." bytes)\n";
         }
 
-        $copyCount++;
+        $count++;
       }
     }
   }
 
-  return $copyCount;
+  return $count;
 }
 
 $parsed = parseArgs($argv);
@@ -125,30 +130,42 @@ $flags = $parsed['flags'];
 $fromDirectory = (isset($args[0])) ? $args[0] : null;
 $toDirectory   = (isset($args[1])) ? $args[1] : null;
 
-if (empty($fromDirectory) || empty($toDirectory))
-{
-  abort("Usage: ". basename(__FILE__) . " [--import|--export] [--aproved] [--language=<language code>] [--debug] <from directory> <to directory>\n");
+if (empty($fromDirectory) || empty($toDirectory)) {
+  abort("Usage: ". basename(__FILE__) . " [--import|--export] [--overwrite|--merge] [--approved] [--language=<language code>] [--debug] <from directory> <to directory>\n");
 }
 
-if (empty($flags['import']) && empty($flags['export']))
-{
+if (empty($flags['overwrite']) && empty($flags['merge'])) {
+  abort('Either the --merge or --overwrite flag should be used with this script.');
+}
+
+if (empty($flags['import']) && empty($flags['export'])) {
   abort('Either the --import or --export flag should be used with this script.');
 }
 
-if (empty($flags['export']) && !empty($flags['approved']))
-{
-  abort("The --approved flag (export transliation units marked 'approved') only works with --export.\n");
+if (empty($flags['export']) && !empty($flags['approved'])) {
+  abort("The --approved flag (export translation units marked 'approved') only works with --export.\n");
 }
 
-$copyCount = migrate($fromDirectory, $toDirectory, $flags);
-
-if (!empty($flags['import']))
-{
-  print "Importing from AtoM... the 'approved' and 'translated' attributes were added for translated units.\n";
+if (!empty($flags['import'])) {
+  print "Importing from AtoM...\n";
+  if (!empty($flags['overwrite'])) {
+    print "The 'approved' and 'translated' attributes will be added for translated units.\n";
+  }
 }
-elseif (!empty($flags['export']))
-{
-  print "Exporting to AtoM... the 'approved' and 'translated' attributes were removed from translation units.\n";
+elseif (!empty($flags['export'])) {
+  print "Exporting to AtoM...\n";
+  if (!empty($flags['overwrite'])) {
+    print "The 'approved' and 'translated' attributes will be removed from translation units.\n";
+  }
 }
 
-print("Done: copied ". $copyCount ." XLIFF files.\n");
+if (!empty($flags['merge'])) {
+  print "Merging XLIFF files...\n";
+}
+else {
+  print "Overwriting any XLIFF files...\n";
+}
+
+$count = migrate($fromDirectory, $toDirectory, $flags);
+
+print("Done: migrated ". $count ." XLIFF files.\n");


### PR DESCRIPTION
### Merge AtoM XLIFF to Weblate

Add a new option to calls to import_from_atom to choose whether XLIFF
files are copied over destination XLIFF files, or source strings are
merged into the target file. Merging is used when updating AtoM strings 
into Weblate work-in-progress translation strings.

### Remove 'translated' XLIFF attribute

Remove all references to the 'translated' attribute on the <trans-unit>
tag. This attribute is not valid XLIFF and is ignored by Weblate.

### Removed import compare

Removed comparison of AtoM strings to Weblate strings in export_to_atom
because the comparison is unnecessary as the files will never be the
same.

### Merge files into AtoM

Merge XLIFF into AtoM's .tx folder instead of overwriting these files
with the Weblate versions.

When merging new translations from Weblate into AtoM, the scripts were
overwriting AtoM's .tx files before the phing scripts ran to import
these strings into AtoM's modules/fixtures etc. This change adds the
ability to merge the Weblate XLIFF into the AtoM XLIFF. This preserves
source strings that are not flagged as "Approved" or have been
accidentally changed in Weblate.

This corrects situations where strings were being removed when the source
string was altered in Weblate.