### PR TITLE
Preserve spacing in source and target strs

### DIFF
--- a/scripts/migrate
+++ b/scripts/migrate
@@ -71,6 +71,8 @@ function migrate($fromI18nDir, $toI18nDir, $options = array())
           removeTranslatedAttribute($toFile);
         }
 
+        setPreserveSpacing($toFile);
+
         if (!empty($options['import'])) {
           formatXliffForWeblate($toFile);
         }


### PR DESCRIPTION
Weblate will remove leading and trailing blank space and newlines when saving modifications to the XLIFF files by default. Set attribute 'xml:space'='preserve' on source and target strings to override this.